### PR TITLE
Fixes for AWS impact test cases

### DIFF
--- a/definitions/impact/delete-secrets-manager-secret.yml
+++ b/definitions/impact/delete-secrets-manager-secret.yml
@@ -17,7 +17,7 @@ input_arguments:
 executors:
   sh:
     code: |
-      aws secretsmanager list-secrets
+      aws secretsmanager delete-secret --secret-id {{ secretid }} --force-delete-without-recovery
   leonidas_aws:
     implemented: True
     clients:

--- a/definitions/impact/delete_login_profile_for_iam_user.yml
+++ b/definitions/impact/delete_login_profile_for_iam_user.yml
@@ -17,7 +17,7 @@ input_arguments:
 executors:
   sh:
     code: |
-      aws iam delete-login-profile -user-name user
+      aws iam delete-login-profile --user-name {{ user }}
   leonidas_aws:
     implemented: True
     clients:


### PR DESCRIPTION
Two test case definitions included incomplete or incorrect syntax for the associated AWS CLI commands.